### PR TITLE
add ppa for php 5.4.x

### DIFF
--- a/owncloud.yaml
+++ b/owncloud.yaml
@@ -121,7 +121,7 @@ resources:
       save_private_key: true
 
   owncloud_server:
-    type: "Rackspace::Cloud::Server"
+    type: "OS::Nova::Server"
     properties:
       name: ownCloud
       flavor: { get_param: flavor }
@@ -129,6 +129,13 @@ resources:
       key_name: { get_resource: ssh_key }
       metadata:
         rax-heat: { get_param: "OS::stack_id" }
+      config_drive: "true"
+      user_data_format: RAW
+      user_data: |
+        #cloud-config
+        apt_sources:
+         - source: "ppa:ondrej/php5-oldstable"
+        package_update: true
 
   owncloud_server_setup:
     type: "OS::Heat::ChefSolo"

--- a/test/fabric/owncloud.py
+++ b/test/fabric/owncloud.py
@@ -11,6 +11,8 @@ def owncloud_is_responding():
         if re.search('web services under your control', page):
             return True
         else:
+            print "oops, didn't find desired text in page."
+            print "page contents was: {}".format(page)
             return False
 
 


### PR DESCRIPTION
Add cloud-init data to server creation to add the ppa
`ondrej/php5-oldstable`, which is maintained by the Debian php5
maintainers and gives us php5* packages at 5.4. Owncloud now requires
5.4.x, so we have to do this to continue to work on Ubuntu 12.04.

This is a stopgap till we get this working on 14.04, which is the proper fix.